### PR TITLE
Extend NodeLinter to support local node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,15 @@ Before using this plugin, you must ensure that `htmlhint` is installed on your s
 
 1. Install [Node.js](http://nodejs.org) (and [npm](https://github.com/joyent/node/wiki/Installing-Node.js-via-package-manager) on Linux).
 
-1. Install the latest `htmlhint` by typing the following in a terminal:
+1. Install the latest `htmlhint` globally by typing the following in a terminal:
    ```
    npm install -g htmlhint@latest
    ```
+Or install `htmlhint` locally in your project folder (**you must have package.json file there**):
+    ```
+    npm init -f
+    npm install htmlhint@latest
+    ```
 
 1. If you are using `nvm` and `zsh`, ensure that the line to load `nvm` is in `.zshenv` and not `.zshrc`.
 

--- a/linter.py
+++ b/linter.py
@@ -11,10 +11,10 @@
 """This module exports the Htmlhint plugin class."""
 
 import sublime
-from SublimeLinter.lint import Linter, persist
+from SublimeLinter.lint import NodeLinter, persist
 
 
-class Htmlhint(Linter):
+class Htmlhint(NodeLinter):
 
     """Provides an interface to htmlhint."""
 


### PR DESCRIPTION
I'm trying to avoid global modules, this allows using a local module with `npm install htmlhint@latest`.
