### PR TITLE
Fix linter missing .htmlhintrc if not in the active directory

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -25,7 +25,7 @@ class Htmlhint(NodeLinter):
     version_requirement = '>= 0.9.13'
     # empty regex so plugin initializes properly
     regex = r''
-    config_file = ('--config', '.htmlhintrc', '~')
+    config_file = ('--config', '.htmlhintrc')
 
     def find_errors(self, output):
         """


### PR DESCRIPTION
Auxiliary directory kill the hierarchy folder search.

Here, the plugin will only look for .htmlhintrc in "\~" or the directory of the inspected file, missing a .htmlhintrc file at the root of the project.

Removing the auxiliary directory will still find a .htmlhintrc file in "~" if no other config file are found while moving up from the directory of the inspected file.