### PR TITLE
Use selector to detect syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
 # command to run tests
 script:
   - flake8 . --max-line-length=120
-  - pep257 . --ignore=D202
+  - pep257 . --ignore=D202 --ignore=D211

--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,9 @@ class Htmlhint(NodeLinter):
 
     """Provides an interface to htmlhint."""
 
-    syntax = 'html'
+    defaults = {
+        'selector': 'text.html'
+    }
     cmd = ('htmlhint', '--format', 'json', '--nocolor', 'stdin')
     version_args = '--version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'

--- a/linter.py
+++ b/linter.py
@@ -36,7 +36,6 @@ class Htmlhint(NodeLinter):
         Calls parse_message for each error found.
 
         """
-
         output_json = sublime.decode_value(output)
 
         # persist.debug('output_json:"{}", file: "{}"'.format(output_json, self.filename))
@@ -46,11 +45,7 @@ class Htmlhint(NodeLinter):
                 yield self.parse_message(message)
 
     def parse_message(self, message):
-        """
-        Parse message object into standard elements of an error and return them.
-
-        """
-
+        """Parse message object into standard elements of an error and return them."""
         error_message = message['message']
         line = message['line'] - 1
         col = message['col']
@@ -68,6 +63,14 @@ class Htmlhint(NodeLinter):
             # ignore info messages by setting message to None
             message = None
 
-        persist.debug('message -- msg:"{}", line:{}, col:{}, error: {}, warning: {}, message_obj:{}'.format(error_message, line, col, error, warning, message))
+        message = 'message -- msg:"{}", line:{}, col:{}, error: {}, warning: {}, message_obj:{}'
+        persist.debug(message.format(
+            error_message,
+            line,
+            col,
+            error,
+            warning,
+            message,
+        ))
 
         return message, line, col, error, warning, error_message, None


### PR DESCRIPTION
**Fixes**: Compatibility with external HTML syntaxes that has a different name but the same root scope. Example: https://github.com/borela/naomi/issues/173

🚨 Please review the [guidelines for contributing](./CONTRIBUTING.md) and our [code of conduct](./CODE_OF_CONDUCT.md) to this repository. 🚨
**Please complete these steps and check these boxes (by putting an x inside the brackets) before filing your PR:**

- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

#### Short description of what this resolves:

Detect any HTML syntax by scope instead of name, this will enable the plugin to work with HTML4, HTML5, etc... syntaxes.

#### Proposed changes:

Add the selector and remove syntax name.

👍 Thank you!
