### PR TITLE
Changing the default source selector to text.html.basic

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -24,7 +24,7 @@ class Htmlhint(NodeLinter):
     """Provides an interface to htmlhint."""
 
     cmd = ("htmlhint", "--format", "json", "--nocolor", "stdin")
-    defaults = {"selector": "source.html"}
+    defaults = {"selector": "text.html.basic"}
 
     def find_errors(self, output):
         """

--- a/linter.py
+++ b/linter.py
@@ -24,7 +24,7 @@ class Htmlhint(NodeLinter):
     """Provides an interface to htmlhint."""
 
     cmd = ("htmlhint", "--format", "json", "--nocolor", "stdin")
-    defaults = {"selector": "text.html"}
+    defaults = {"selector": "source.html"}
 
     def find_errors(self, output):
         """


### PR DESCRIPTION
The previous selecctor text.html was affecting other filetypes such as: 
PHP (embedding.php text.html.php ) 
MD (text.html.markdown)